### PR TITLE
Parameterize Scylla Repo Options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,13 @@ class scylla (
   $scylla_args                          = $scylla::params::scylla_args,
   $scylla_config_options                = $scylla::params::scylla_config_options,
   $set_up_io_benchmark                  = $scylla::params::set_up_io_benchmark,
+  $apt_key_id                           = $scylla::params::apt_key_id,
+  $apt_key_server                       = $scylla::params::apt_key_server,
+  $distro_release                       = $scylla::params::distro_release,
+  $distro_repos                         = $scylla::params::distro_repos,
+  $apt_key                              = $scylla::params::apt_key,
+  $apt_location                         = $scylla::params::apt_location,
+  $squid_proxy                          = $scylla::params::squid_proxy,
 
   ) inherits scylla::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,9 @@
 class scylla::params {
 
   # ScyllaDB version
-  $major_version                         = '3.0'
-  $minor_version                         = '10-0'
-  $release                               = '20190815.b3bfd8c08-1~stretch'
+  $major_version                         = '4.2'
+  $minor_version                         = '0-0'
+  $release                               = '20201025.94597e38e2-1'
 
   # scylla.yaml
   $cluster_name                          = 'ScyllaCluster'
@@ -65,5 +65,12 @@ class scylla::params {
   # Scylla extra options
   $scylla_config_options                  = undef
   $set_up_io_benchmark                    = false
+  $apt_key_id                             = '7752A0722F457FB76C0F44985E08FBD8B5D6EC9C'
+  $apt_key_server                         = 'keyserver.ubuntu.com'
+  $distro_release                         = $::os['distro']['codename']
+  $distro_repos                           = 'non-free'
+  $apt_key                                = '5e08fbd8b5d6ec9c'
+  $apt_location                           = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2'
+  $squid_proxy                            = 'http-proxy="http://squid.zattoo.com:3128 "'
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class scylla::params {
   $distro_release                         = $::os['distro']['codename']
   $distro_repos                           = 'non-free'
   $apt_key                                = '5e08fbd8b5d6ec9c'
-  $apt_location                           = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2'
+  $apt_location                           = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.4'
   $squid_proxy                            = 'http-proxy="http://squid.zattoo.com:3128 "'
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,9 @@
 class scylla::params {
 
   # ScyllaDB version
-  $major_version                         = '4.4'
+  $major_version                         = '4.2'
   $minor_version                         = '0-0'
-  $release                               = '20210322.dffbcabbb-1'
+  $release                               = '20201025.94597e38e2-1'
 
   # scylla.yaml
   $cluster_name                          = 'ScyllaCluster'
@@ -70,7 +70,7 @@ class scylla::params {
   $distro_release                         = $::os['distro']['codename']
   $distro_repos                           = 'non-free'
   $apt_key                                = '5e08fbd8b5d6ec9c'
-  $apt_location                           = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.4'
+  $apt_location                           = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2'
   $squid_proxy                            = 'http-proxy="http://squid.zattoo.com:3128 "'
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,9 +6,9 @@
 class scylla::params {
 
   # ScyllaDB version
-  $major_version                         = '4.2'
+  $major_version                         = '4.4'
   $minor_version                         = '0-0'
-  $release                               = '20201025.94597e38e2-1'
+  $release                               = '20210322.dffbcabbb-1'
 
   # scylla.yaml
   $cluster_name                          = 'ScyllaCluster'

--- a/manifests/repo/scylla_repo.pp
+++ b/manifests/repo/scylla_repo.pp
@@ -1,11 +1,12 @@
 # For Debian 9 only
 class scylla::repo::scylla_repo (
-  $key_id     = '7752A0722F457FB76C0F44985E08FBD8B5D6EC9C',
-  $key_server = 'keyserver.ubuntu.com',
-  $release    = $::os['distro']['codename'],
-  $repos      = 'non-free',
-  $apt_key    = '5e08fbd8b5d6ec9c',
-  $location   = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2',) {
+  $key_id      = $::scylla::apt_key_id,
+  $key_server  = $::scylla::apt_key_server,
+  $release     = $::scylla::distro_release,
+  $repos       = $::scylla::distro_repos,
+  $apt_key     = $::scylla::apt_key,
+  $location    = $::scylla::apt_location,
+  $squid_proxy = $::scylla::squid_proxy,) {
 
     package { 'gnupg2':
       ensure => present,
@@ -17,8 +18,8 @@ class scylla::repo::scylla_repo (
         #include apt::update
         apt::key {'scylla':
           id     => $key_id,
-          server => 'keyserver.ubuntu.com',
-          options => 'http-proxy="http://squid.zattoo.com:3128 " --recv-keys "${apt_key}"',
+          server => "${key_server}",
+          options => '"${squid_proxy}" --recv-keys "${apt_key}"',
         }
 
         apt::source { 'scylla.source.https.list':


### PR DESCRIPTION
This will make sure that future upgrades can be done without making significant changes to this module. Now each Scylla Cluster could maintain its separate version; hence would reduce upgrade complexity. 